### PR TITLE
Add nvim-autopairs plugin

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -104,6 +104,7 @@ in
       fidget-nvim
 
       nvim-cmp
+      nvim-autopairs
       cmp-nvim-lsp
       luasnip
       cmp_luasnip


### PR DESCRIPTION
Currently, there is no Plugin for autopairs in vim configs